### PR TITLE
Corrected incorrect require for highcharts-more in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 In your JavaScript manifest (application.js):
 
 	//= require highstock
-	//= require highstock/modules/highstock-more
+	//= require highstock/highcharts-more
 
 Refer to the [Highstock documentation](http://api.highcharts.com/highstock) for more information.
 


### PR DESCRIPTION
The readme incorrectly refers to highstock/modules/highstock-more corrected this to point to the highcharts-more which does exist
